### PR TITLE
Align workshop dates with luma events

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Schedule
 - ​Nov 4: Part 1: Foundations of Prompting, RAG systems, Agents and Evaluations
-- ​Nov 18: Part 2: Scale and Productionize AI Systems
+- ​Nov 25: Part 2: Scale and Productionize AI Systems
 - ​Dec 16: Part 3: Build and deploy a GenAI app end-to-end
 
 [Sign up](https://lu.ma/wandb?tag=class)


### PR DESCRIPTION
## Description

This PR aims to align the date of the second workshop on the homepage with the one in Luma (also announced in the live workshop).